### PR TITLE
Fixing squid: S1168 Empty arrays and collections should be returned instead of null

### DIFF
--- a/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
+++ b/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
@@ -86,7 +86,7 @@ public class CountryPicker extends DialogFragment implements Comparator<Country>
         e.printStackTrace();
       }
     }
-    return null;
+    return Collections.emptyList();
   }
 
   private static String readEncodedJsonString() throws java.io.IOException {


### PR DESCRIPTION
 "This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1168- “ Empty arrays and collections should be returned instead of null”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1168
 Please let me know if you have any questions.
Fevzi Ozgul