### PR TITLE
Pull request, add getCountryByLocale and getCountryByName

### DIFF
--- a/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
+++ b/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
@@ -2,6 +2,7 @@ package com.mukesh.countrypicker.fragments;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.telephony.TelephonyManager;
@@ -172,20 +173,21 @@ public class CountryPicker extends DialogFragment implements Comparator<Country>
     this.context = context;
     getAllCountries();
     TelephonyManager telephonyManager =
-        (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+            (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
     if (!(telephonyManager.getSimState() == TelephonyManager.SIM_STATE_ABSENT)) {
       return getCountry(telephonyManager.getSimCountryIso());
     }
     return afghanistan();
   }
 
-  public Country getCountryByLocale( Locale locale ) {
-    String countryIsoCode = locale.getISO3Country();
+  public Country getCountryByLocale( Context context, Locale locale ) {
+    this.context = context;
+    String countryIsoCode = locale.getISO3Country().substring(0,2).toLowerCase();
     return getCountry(countryIsoCode);
   }
 
-  public Country getCountryByName ( String countryName ) {
-
+  public Country getCountryByName ( Context context, String countryName ) {
+    this.context = context;
     Map<String, String> countries = new HashMap<>();
     for (String iso : Locale.getISOCountries()) {
       Locale l = new Locale("", iso);
@@ -200,7 +202,7 @@ public class CountryPicker extends DialogFragment implements Comparator<Country>
   }
 
   private Country getCountry( String countryIsoCode ) {
-
+    getAllCountries();
     for (int i = 0; i < allCountriesList.size(); i++) {
       Country country = allCountriesList.get(i);
       if (country.getCode().equalsIgnoreCase(countryIsoCode)) {

--- a/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
+++ b/countrypicker/src/main/java/com/mukesh/countrypicker/fragments/CountryPicker.java
@@ -28,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Currency;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Created by mukesh on 25/04/16.
@@ -169,17 +171,41 @@ public class CountryPicker extends DialogFragment implements Comparator<Country>
   public Country getUserCountryInfo(Context context) {
     this.context = context;
     getAllCountries();
-    String countryIsoCode;
     TelephonyManager telephonyManager =
         (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
     if (!(telephonyManager.getSimState() == TelephonyManager.SIM_STATE_ABSENT)) {
-      countryIsoCode = telephonyManager.getSimCountryIso();
-      for (int i = 0; i < allCountriesList.size(); i++) {
-        Country country = allCountriesList.get(i);
-        if (country.getCode().equalsIgnoreCase(countryIsoCode)) {
-          country.setFlag(getFlagResId(country.getCode()));
-          return country;
-        }
+      return getCountry(telephonyManager.getSimCountryIso());
+    }
+    return afghanistan();
+  }
+
+  public Country getCountryByLocale( Locale locale ) {
+    String countryIsoCode = locale.getISO3Country();
+    return getCountry(countryIsoCode);
+  }
+
+  public Country getCountryByName ( String countryName ) {
+
+    Map<String, String> countries = new HashMap<>();
+    for (String iso : Locale.getISOCountries()) {
+      Locale l = new Locale("", iso);
+      countries.put(l.getDisplayCountry(), iso);
+    }
+
+    String countryIsoCode = countries.get(countryName);
+    if (countryIsoCode != null) {
+      return getCountry(countryIsoCode);
+    }
+    return afghanistan();
+  }
+
+  private Country getCountry( String countryIsoCode ) {
+
+    for (int i = 0; i < allCountriesList.size(); i++) {
+      Country country = allCountriesList.get(i);
+      if (country.getCode().equalsIgnoreCase(countryIsoCode)) {
+        country.setFlag(getFlagResId(country.getCode()));
+        return country;
       }
     }
     return afghanistan();


### PR DESCRIPTION
In order to expand the usability of the library to fetch the drawables it contains, two new methods were added. They have been tested manually, and if interested I could add a new field to the test app for their usage. This pull request addresses issue  #12.

```
  public Country getCountryByLocale( Context context, Locale locale ) {
    this.context = context;
    String countryIsoCode = locale.getISO3Country().substring(0,2).toLowerCase();
    return getCountry(countryIsoCode);
  }

  public Country getCountryByName ( Context context, String countryName ) {
    this.context = context;
    Map<String, String> countries = new HashMap<>();
    for (String iso : Locale.getISOCountries()) {
      Locale l = new Locale("", iso);
      countries.put(l.getDisplayCountry(), iso);
    }
```

For making this possible, a part of ``public Country getUserCountryInfo(Context context)`` was refactored out into it's own function to be reused, and is now found in 
```
  private Country getCountry( String countryIsoCode ) {
    getAllCountries();
    for (int i = 0; i < allCountriesList.size(); i++) {
      Country country = allCountriesList.get(i);
      if (country.getCode().equalsIgnoreCase(countryIsoCode)) {
        country.setFlag(getFlagResId(country.getCode()));
        return country;
       }
    } 
  }
```
