### PR TITLE
added getAllCountries() method fixes #79

### DIFF
--- a/countrypicker/src/main/java/com/mukesh/countrypicker/CountryPicker.java
+++ b/countrypicker/src/main/java/com/mukesh/countrypicker/CountryPicker.java
@@ -527,6 +527,10 @@ public class CountryPicker implements BottomSheetInteractionListener {
     sortCountries(this.countries);
   }
 
+  public List<Country> getAllCountries(){
+    return countries;
+  }
+  
   public Country getCountryFromSIM() {
     TelephonyManager telephonyManager =
         (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);


### PR DESCRIPTION
The documentation says that the CountryPicker class has a utility method called **getAllCountries()** which returns a list of all the countries available. But this method is missing.

I have added the getAllCountries() method in this PR. 