### PR TITLE
Force state expanded to bottom sheet dialog

### DIFF
--- a/countrypicker/src/main/java/com/mukesh/countrypicker/BottomSheetDialogView.java
+++ b/countrypicker/src/main/java/com/mukesh/countrypicker/BottomSheetDialogView.java
@@ -3,11 +3,16 @@ package com.mukesh.countrypicker;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.BottomSheetDialog;
 import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.FrameLayout;
+
 import com.mukesh.countrypicker.listeners.BottomSheetInteractionListener;
 
 import static com.mukesh.countrypicker.CountryPicker.THEME_NEW;
@@ -41,7 +46,7 @@ public class BottomSheetDialogView extends BottomSheetDialogFragment {
 
   @Nullable @Override
   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
-      @Nullable Bundle savedInstanceState) {
+          @Nullable Bundle savedInstanceState) {
     return inflater.inflate(R.layout.country_picker, container, false);
   }
 
@@ -51,6 +56,22 @@ public class BottomSheetDialogView extends BottomSheetDialogFragment {
     listener.setCustomStyle(view);
     listener.setSearchEditText();
     listener.setupRecyclerView(view);
+
+    // This fix collapsed behavior into landscape forcing it into STATE_HALF_EXPANDED
+    view.getViewTreeObserver().addOnGlobalLayoutListener(
+            new ViewTreeObserver.OnGlobalLayoutListener() {
+              @Override
+              public void onGlobalLayout() {
+                if (getDialog() != null) {
+                  BottomSheetDialog bsd = (BottomSheetDialog) getDialog();
+                  FrameLayout fl = bsd.findViewById(android.support.design.R.id.design_bottom_sheet);
+                  if (fl != null) {
+                    BottomSheetBehavior bsb = BottomSheetBehavior.from(fl);
+                    bsb.setState(BottomSheetBehavior.STATE_HALF_EXPANDED);
+                  }
+                }
+              }
+            });
   }
 
   public void setListener(BottomSheetInteractionListener listener) {


### PR DESCRIPTION
## Proposed changes
Fix collapsed behavior into landscape forcing it into STATE_HALF_EXPANDED
Based on https://medium.com/@OguzhanAlpayli/bottom-sheet-dialog-fragment-expanded-full-height-65b725c8309

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x ] Any dependent changes have been merged and published in downstream modules

## Further comments

